### PR TITLE
Prevent firewall from nagging everytime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 all:
 	go install vole
-	vole
+	./bin/vole

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 all:
-	go run src/vole/vole.go
+	go install vole
+	vole


### PR DESCRIPTION
MacOSX firewall allows exceptions, but with `go run` it builds a new binary in a random temp folder name, so firewall asks everytime to allow connections as it thinks it's a new application.

Changing the make to do this will run the same binary thus allowing firewall to remember the exception.
