### PR TITLE
Remove default max-width from images

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,8 +25,8 @@
   min-height: 800px;
 }
 
-img {
-  max-width: none;
+.post img {
+  max-width: 800px;
 }
 
 #my-username-title {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,7 +25,7 @@
   min-height: 800px;
 }
 
-.post img {
+.post .span6 img {
   -webkit-transition: .3s all ease-in-out;
      -moz-transition: .3s all ease-in-out;
       -ms-transition: .3s all ease-in-out;
@@ -33,7 +33,7 @@
           transition: .3s all ease-in-out;
 }
 
-.post img.full {
+.post .span6 img.full {
   max-width: 800px;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -26,6 +26,14 @@
 }
 
 .post img {
+  -webkit-transition: .3s all ease-in-out;
+     -moz-transition: .3s all ease-in-out;
+      -ms-transition: .3s all ease-in-out;
+       -o-transition: .3s all ease-in-out;
+          transition: .3s all ease-in-out;
+}
+
+.post img.full {
   max-width: 800px;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,6 +25,10 @@
   min-height: 800px;
 }
 
+img {
+  max-width: none;
+}
+
 #my-username-title {
   color: #888888;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -176,5 +176,6 @@
   <script src="/js/vendor/ember-latest.js"></script>
   <script src="/js/vendor/ember-data-latest.js"></script>
   <script src="/js/vole.js"></script>
+  <script src="/js/ui.js"></script>
 </body>
 </html>

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,0 +1,10 @@
+/**
+ * Pretty stuff
+ */
+(function($){
+  // Expand images to full-size clicked
+  $('.post img').click(function(e){
+    e.preventDefault();
+    $(this).toggleClass('full');
+  });
+})(jQuery);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -3,7 +3,7 @@
  */
 (function($){
   // Expand images to full-size clicked
-  $('.post img').click(function(e){
+  $(document).on('click', '.post .span6 img', function(e) {
     e.preventDefault();
     $(this).toggleClass('full');
   });


### PR DESCRIPTION
This just overrides one tiny setting in Bootstrap, and the result is images can be wide than the post width:

![screen shot 2013-06-26 at 9 43 27 pm](https://f.cloud.github.com/assets/254753/713590/fb1d4916-ded3-11e2-8e2f-7df8423b2261.png)
