### PR TITLE
 #51 : display backend's health

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -29,6 +29,19 @@
   color: #888888;
 }
 
+body #backend-health {
+  color: green;
+}
+body #backend-health:after {
+  content: "on";
+}
+body.backend-off #backend-health {
+   color: red;
+}
+body.backend-off #backend-health:after {
+  content: "off";
+}
+
 .post {
   border-top: 1px #f2f2f2 solid;
   padding: 10px 0 10px 0;

--- a/static/index.html
+++ b/static/index.html
@@ -24,6 +24,7 @@
             </div>
           {{/if}}
         </div>
+        <div class="span1"><h3 id="backend-health"></h3></div>
       </div>
     </header>
 

--- a/static/js/vole.js
+++ b/static/js/vole.js
@@ -214,6 +214,15 @@
     return new Handlebars.SafeString(escaped.replace(/\n/g, '<br />'));
   });
 
+  //-------------------------
+  // Display backend health
+  //-------------------------
+  $(document).ajaxError(function() {
+    $( "body" ).addClass( "backend-off" );
+  }).ajaxSuccess(function() {
+    $( "body" ).removeClass( "backend-off" );
+  });
+
   $('.time').moment({ frequency: 5000 });
 
 })(jQuery, Ember);


### PR DESCRIPTION
We add two callbacks to jQuery.ajax(); success and error, which toggle a class=backend-off on the body
A tentative interface displays the result in CSS in the header (functional but not really pretty).
