### PR TITLE
ISSUE-89 Overriding blockquote p bootstrap style

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -37,6 +37,10 @@
   max-width: 800px;
 }
 
+.post blockquote p {
+  font-size: 14px;
+}
+
 #my-username-title {
   color: #888888;
 }


### PR DESCRIPTION
This closes #89 by keeping blockquote text the same size as normal
text (14px).
