### PR TITLE
Links in new window: don't parse content twice

### DIFF
--- a/static/js/app/templates/helpers.js
+++ b/static/js/app/templates/helpers.js
@@ -3,10 +3,9 @@ define([
   'ember',
   'handlebars',
   'lib/marked',
-  'moment',
-  'jquery'
+  'moment'
 ],
-function (Ember, Handlebars, marked, moment, $) {
+function (Ember, Handlebars, marked, moment) {
 
   Ember.Handlebars.registerBoundHelper('nanoDate', function(value, options) {
     var escaped = Handlebars.Utils.escapeExpression(value);
@@ -21,14 +20,7 @@ function (Ember, Handlebars, marked, moment, $) {
       breaks: true
     });
 
-  var html = $('<div>')
-    .html(marked(content))
-    .find('a')
-      .attr('target', '_blank')
-    .end()
-    .html();
-
-    return new Handlebars.SafeString(html);
+    return new Handlebars.SafeString(marked(content));
   });
 
 });

--- a/static/js/lib/marked.js
+++ b/static/js/lib/marked.js
@@ -577,7 +577,7 @@ InlineLexer.prototype.output = function(src) {
       }
       out += '<a href="'
         + href
-        + '">'
+        + '" target="_blank">'
         + text
         + '</a>';
       continue;
@@ -597,7 +597,7 @@ InlineLexer.prototype.output = function(src) {
       else {
         out += '<a href="'
           + href
-          + '">'
+          + '" target="_blank">'
           + text
           + '</a>';
         }
@@ -705,7 +705,7 @@ InlineLexer.prototype.outputLink = function(cap, link) {
   if (cap[0][0] !== '!') {
     return '<a href="'
       + escape(link.href)
-      + '"'
+      + '" target="_blank"'
       + (link.title
       ? ' title="'
       + escape(link.title)


### PR DESCRIPTION
Was there a reason for using jQuery in #90? Parsing the content twice seems wasteful. This reverts that PR and uses marked parser.
