### PR TITLE
Markdown previews of posts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -81,6 +81,12 @@
   display: block;
 }
 
+#preview-text {
+  border: 2px dotted #ccc;
+  padding: 3px;
+  min-height: 30px;
+}
+
 .load-more {
   width: 100%;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -41,6 +41,9 @@
               <div class="span7">
                 <textarea id="post-text" placeholder="Say something..." rows="3" class="span7"></textarea>
               </div>
+              <div class="span7">
+                <p id="preview-text" class="invisible"></p>
+              </div>
             </div>
             <div class="row">
               <div class="span2 offset5">

--- a/static/js/app/postbox.js
+++ b/static/js/app/postbox.js
@@ -1,27 +1,41 @@
 
 define([
 	'flight/component',
-	'app/api'
-], function (component, API) {
+	'app/api',
+	'lib/marked'
+], function (component, API, marked) {
 
 	function postbox () {
 
 		this.defaultAttrs({
 			textareaSelector : 'textarea',
-			buttonSelector : '#post-button'
+			previewSelector  : '#preview-text',
+			buttonSelector   : '#post-button'
 		});
 
 		this.post = function () {
 			var textarea = this.select('textareaSelector');
-
+			this.select('previewSelector').html('');
 			API.post(textarea.val()).done(function () {
 				textarea.val('');
 			}.bind(this));
 		};
 
 		this.keyup = function () {
-			var disabled = (this.select('textareaSelector').val().length === 0);
+			var textarea = this.select('textareaSelector');
+			var disabled = (textarea.val().length === 0);
+			var height = textarea.innerHeight();
+			var scrollHeight = textarea[0].scrollHeight;
+
+			//Respond to overflows in textarea content
+			if( scrollHeight > height ){
+				textarea.height(scrollHeight);
+			}
+
 			this.select('buttonSelector').prop('disabled', disabled);
+			this.select('previewSelector')
+				.html(marked(textarea.val()))
+				.toggleClass('invisible', disabled);
 		};
 
 		this.after('initialize', function () {


### PR DESCRIPTION
Preview hide/shows based on value of textarea
The composition textarea resizes based off input

![004f26e59cff1ef6ac4654c3c90bfaaa](https://f.cloud.github.com/assets/239123/1845234/919b8ab0-7579-11e3-8521-a73aa020fcbe.png)

This resolves #99 
